### PR TITLE
ci: add branch protection and auto-deletion workflows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## Pull Request Type
+<!-- Please check the one that applies to this PR using "x". -->
+```
+[ ] Merge to main (from holder only)
+[ ] Merge to holder (from feature/fix branch)
+```
+
+## Description
+<!-- Describe your changes in detail -->
+
+## Related Issue
+<!-- Please link to the issue here: -->
+
+## Motivation and Context
+<!-- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+<!-- Please describe in detail how you tested your changes. -->
+<!-- Include details of your testing environment, and the tests you ran to -->
+<!-- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Other... Please describe:
+
+## Checklist:
+<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+```
+[ ] My code follows the code style of this project.
+[ ] My change requires a change to the documentation.
+[ ] I have updated the documentation accordingly.
+[ ] I have read the **CONTRIBUTING** document.
+[ ] I have added tests to cover my changes.
+[ ] All new and existing tests passed.
+[ ] I have checked my code and corrected any misspellings.
+```

--- a/.github/workflows/auto-delete-branch.yml
+++ b/.github/workflows/auto-delete-branch.yml
@@ -1,0 +1,18 @@
+name: Auto Delete Branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [holder]
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'feature/') || startsWith(github.head_ref, 'fix/') || startsWith(github.head_ref, 'docs/') || startsWith(github.head_ref, 'chore/') || startsWith(github.head_ref, 'refactor/') || startsWith(github.head_ref, 'test/') || startsWith(github.head_ref, 'ci/') || startsWith(github.head_ref, 'build/') || startsWith(github.head_ref, 'perf/')
+    steps:
+      - name: Delete branch
+        uses: SvanBoxel/delete-merged-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          delete_closed_pr: true

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,29 @@
+name: Branch Protection
+
+on:
+  push:
+    branches: [ main, holder ]
+  pull_request:
+    branches: [ main, holder ]
+
+jobs:
+  branch-protection:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" && "${{ github.event_name }}" == "push" ]]; then
+            echo "Direct pushes to main branch are not allowed"
+            exit 1
+          fi
+          
+          if [[ "${{ github.base_ref }}" == "main" && "${{ github.head_ref }}" != "holder" ]]; then
+            echo "Only holder branch can be merged into main"
+            exit 1
+          fi
+          
+          if [[ "${{ github.head_ref }}" != "holder" && ! "${{ github.head_ref }}" =~ ^(feature|fix|docs|chore|refactor|test|ci|build|perf)/[a-z0-9-]+$ ]]; then
+            echo "Branch names must follow the pattern: <type>/<name>"
+            echo "Valid types: feature, fix, docs, chore, refactor, test, ci, build, perf"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ stats = (
 )
 ```
 
+## 🔒 Branch Protection
+
+This repository enforces branch protection:
+- No direct commits to `main` branch
+- All changes must go through `holder` branch first
+- Feature branches must follow naming convention: `feature/*`, `fix/*`, etc.
+
 ## ⚠️ Limitations
 
 - Not for production use


### PR DESCRIPTION
This PR adds:

- Branch protection workflow to enforce:
  - Only feature branches can merge to holder
  - Only holder can merge to main
  - No direct pushes to main

- Auto-deletion workflow to:
  - Delete feature branches after successful merge to holder
  - Keep repository clean

Tested:
- Branch naming rules
- Merge restrictions
- Branch deletion logic